### PR TITLE
Centralized configuration and supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN service mysql start && \
 
 #
 # Install Apache
-# 
+#
 
 RUN apt-get install -y apache2
 
@@ -38,7 +38,7 @@ RUN apt-get install -y apache2
 # Dependencies
 RUN apt-get install -y libcurl3 libjansson4
 
-#RUN wget https://github.com/pingidentity/mod_auth_openidc/releases/download/v1.3/libapache2-mod-auth-openidc_1.3_amd64.deb 
+#RUN wget https://github.com/pingidentity/mod_auth_openidc/releases/download/v1.3/libapache2-mod-auth-openidc_1.3_amd64.deb
 RUN wget https://github.com/pingidentity/mod_auth_openidc/releases/download/v1.5/libapache2-mod-auth-openidc_1.5_amd64.deb
 RUN dpkg -i libapache2-mod-auth-openidc_1.5_amd64.deb
 
@@ -118,16 +118,25 @@ ADD html/imgs /var/www/html/imgs
 ADD code-mirror/mode /var/www/html/mode
 ADD code-mirror/lib /var/www/html/lib
 
-
 #
 # Copy AdmiralEdu to container
 #
 ADD server /home/admiraledu/server
 
+#
+# Install supervisord
+#
+RUN apt-get install -y supervisor
+ADD docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+#
+# Apache fails to start on install since it has unbound variables. That puts
+# it into an inconsistent state. The line below cleans up.
+#
+RUN service apache2 start; service apache2 stop
 
 #
 # Run AdmiralEdu
 #
 
-#WORKDIR /home/admiraledu
-CMD service apache2 start; service mysql start; su admiraledu -c 'cd ~/; racket server/captain-teach.rkt'
+CMD supervisord

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
+include config
+
+ENV = -e ClientID=$(ClientID) \
+	-e ClientSecret=$(ClientSecret) \
+	-e AdminEmail=$(AdminEmail) \
+	-e RedirectUri=$(RedirectUri) \
+	-e BaseUrl=$(BaseUrl) \
+	-e CryptoPassphrase=$(CryptoPassphrase) \
+	-e AdminEmail=$(AdminEmail)
+
 all:
 	docker build -t admiral-edu .
 
 run: all
-	docker run -i -t --rm -p 443:443 admiral-edu 
+	docker run -i -t --rm -p 443:443 $(ENV) admiral-edu
 
 bash: all
-	docker run -i -t --rm -p 443:443 admiral-edu /bin/bash
+	docker run -i -t --rm -p 443:443 $(ENV) admiral-edu /bin/bash

--- a/README.md
+++ b/README.md
@@ -5,13 +5,19 @@
 1. Create a project on the [Google Developer Console](https://console.developers.google.com/)
 
 2. Once you are on the project page, in the side menu select APIs & auth > Credentials.
-  * Click Create a New Client ID 
+  * Click Create a New Client ID
   * Add https://localhost/redirect to the AUTHORIZED REDIRECT URI section
   * Click Create Client ID
 
-3. Copy the Client ID field into docker/captain-teach.conf to the OIDCClientID field.
+3. Create a `config` file based on `config.sample`:
 
-4. Copy the Client secret field into docker/captain-teach.conf to the OIDCClientSecret field.
+     $ cp config.sample config
+
+4. Copy the Client ID, Client Secret, and RedirectUri values from the
+   Google Developers Console into the `config` file you created above.
+
+   Edit other settings in `config`, such as the hostname. These are obvious.
+
 
 ### Configuring Service
 

--- a/config.sample
+++ b/config.sample
@@ -1,0 +1,14 @@
+# Set these variables and save as config
+
+# Get these from the Google Developers Console
+ClientID = very-long-string.apps.googleusercontent.com
+ClientSecret = shorter-string
+RedirectUri = https://localhost/ct/redirect
+
+# This the URL where the site is hosted (no trailing slash)
+BaseUrl = https://localhost
+
+CryptoPassphrase = aBetterPassword
+
+AdminEmail = jcollard@cs.umass.edu
+

--- a/docker/captain-teach-http.conf
+++ b/docker/captain-teach-http.conf
@@ -1,20 +1,11 @@
 
 <VirtualHost *:80>
 
-	#######################################
-	# You probably want to change this
-	#######################################	
-	ServerAdmin webmaster@localhost
+	ServerAdmin ${AdminEmail}
 	DocumentRoot /var/www/html
-
-	###########################################################
-	# Redirect all traffic on 80 to https
-	# You need to modify this to be your site (or optionally remove it)
-	###########################################################
-	Redirect permanent / https://localhost/
+	Redirect permanent / ${BaseUrl}
 
 	ErrorLog ${APACHE_LOG_DIR}/error.log
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
-
 
 </VirtualHost>

--- a/docker/captain-teach-ssl.conf
+++ b/docker/captain-teach-ssl.conf
@@ -1,11 +1,7 @@
 <IfModule mod_ssl.c>
 	<VirtualHost _default_:443>
 
-		##################################
-		# You probably want to change this
-		##################################
-
-		ServerAdmin webmaster@localhost
+		ServerAdmin ${AdminEmail}
 
 		DocumentRoot /var/www/html
 
@@ -16,7 +12,7 @@
 		SSLCertificateFile	/etc/ssl/certs/ssl-cert-snakeoil.pem
 		SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
 		#SSLCertificateChainFile /etc/apache2/ssl.crt/server-ca.crt
-		
+
 		ErrorLog ${APACHE_LOG_DIR}/error.log
 		CustomLog ${APACHE_LOG_DIR}/access.log combined
 

--- a/docker/captain-teach.conf
+++ b/docker/captain-teach.conf
@@ -4,17 +4,12 @@
 
 # These can be found on the Google Developer Console
 # console.developers.google.com
-OIDCClientID ????
-OIDCClientSecret ????
+OIDCClientID ${ClientID}
+OIDCClientSecret ${ClientSecret}
 
-############################################
-# The following may be optionally modified #
-############################################ 
-
-OIDCRedirectURI https://localhost/ct/redirect
-OIDCCryptoPassphrase aBetterPassword
+OIDCRedirectURI ${RedirectUri}
+OIDCCryptoPassphrase ${CryptoPassphrase}
 OIDCScope "email"
-
 
 OIDCProviderIssuer accounts.google.com
 OIDCProviderAuthorizationEndpoint https://accounts.google.com/o/oauth2/auth
@@ -29,7 +24,7 @@ OIDCCookiePath /ct/
 ###################################
 # Protect traffic to this location
 ##################################
-<Location /ct/ >	
+<Location /ct/ >
   Authtype openid-connect
   require valid-user
 </Location>
@@ -37,4 +32,3 @@ OIDCCookiePath /ct/
 # The default setting is to run captain-teach on port 8080
 ProxyPass /ct/ http://localhost:8080/
 ProxyPassReverse /ct/ http://localhost:8080/
-

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:admiral-edu]
+command=racket server/captain-teach.rkt
+redirect_stderr=true
+directory=/home/admiraledu
+
+
+[program:apache2]
+command=/bin/bash -c "source /etc/apache2/envvars && apache2 -DFOREGROUND"
+redirect_stderr=true
+
+[program:mysql]
+command=/usr/sbin/mysqld
+redirect_stderr=true


### PR DESCRIPTION
This commit does two things:
1. Configurations that were spread across docker/*.conf are now in a single
   config file and passed to the container using environment variables.
2. The three processes in the container (MySQL, Apache, and Racket) are now
   managed by supervisord. This will keep the system running when things crash.

The SSL configuration files still need to be manually hacked in.
