### PR TITLE
avoid extra margins that break layout

### DIFF
--- a/html/css/file-container.css
+++ b/html/css/file-container.css
@@ -16,6 +16,7 @@ body {
 	 height: 100%;
    border: 1px solid #ccc;
    border-radius: 5px;
+   box-sizing: border-box;
    overflow: hidden;
 }
 
@@ -137,7 +138,6 @@ a:hover {
 }
 
 .syntax-menu p {
-	margin-top: 5px;
-	margin-right: 20px;
-	float: right;
+  margin: 5px 20px 0 0;
+  float: right;
 }

--- a/html/css/review.css
+++ b/html/css/review.css
@@ -131,3 +131,7 @@ input[type=submit]:hover {
 	background: #aaa;
 	color: #000;
 }
+
+.submit-button.hidden {
+    display: none;
+}

--- a/server/pages/review.rkt
+++ b/server/pages/review.rkt
@@ -32,7 +32,7 @@
          (completed (review:Record-completed review))
          (updir (apply string-append (repeat "../" (+ (length rest) 1))))
          (root-url updir)
-         [no-modifications (if completed "<p>This review has already been submitted. Modifications will not be saved.</p>" "")]
+         [no-modifications (if completed "This review has already been submitted. Modifications will not be saved." "")]
          [submit-hidden (if completed "hidden" "")]
          [submit-url (if completed "#" (string-append start-url root-url "review/submit/" r-hash "/"))]
          (updir-rubric (apply string-append (repeat "../" (- (length rest) 1))))


### PR DESCRIPTION
The extra few pixels of border on `.file-container` and the browser-default margins on `.syntax-menu p` and the no-modifications `p` lead to containers that scroll by only a few pixels on `browse` and `review`.

For instance, in Firefox `browse` looks like this to me (note the outer scrollbar and the gap above the inner scrollbar):
![scroll](https://cloud.githubusercontent.com/assets/227091/6192937/96b3cd60-b36b-11e4-80a0-c424462d315a.png)

This change largely fixes those problems.

And while I'm at it, this also makes the review submit button actually hidden on a completed review.

cc @jbclements