### PR TITLE
update timestamp default

### DIFF
--- a/server/database/mysql/review.rkt
+++ b/server/database/mysql/review.rkt
@@ -33,9 +33,9 @@
 
 (provide time-stamp time-stamp-type time-stamp-type-1)
 (define time-stamp "time_stamp")
-(define time-stamp-type "TIMESTAMP DEFAULT 0")
+(define time-stamp-type "TIMESTAMP DEFAULT '1970-01-01 00:00:01'")
 (define time-stamp-type-0 "TIMESTAMP")
-(define time-stamp-type-1 "TIMESTAMP DEFAULT 0")
+(define time-stamp-type-1 "TIMESTAMP DEFAULT '1970-01-01 00:00:01'")
 
 (provide feedback-viewed-time-stamp
          feedback-viewed-time-stamp-type

--- a/server/database/mysql/submission.rkt
+++ b/server/database/mysql/submission.rkt
@@ -29,9 +29,9 @@
 
 (provide time-stamp time-stamp-type time-stamp-type-1)
 (define time-stamp "time_stamp")
-(define time-stamp-type "TIMESTAMP DEFAULT 0")
+(define time-stamp-type "TIMESTAMP DEFAULT '1970-01-01 00:00:01'")
 (define time-stamp-type-0 "TIMESTAMP")
-(define time-stamp-type-1 "TIMESTAMP DEFAULT 0")
+(define time-stamp-type-1 "TIMESTAMP DEFAULT '1970-01-01 00:00:01'")
 
 (provide times-reviewed times-reviewed-type)
 (define times-reviewed "times_reviewed")


### PR DESCRIPTION
This pull request simply changes "DEFAULT 0" to "DEFAULT '1970 etc. etc.'" in four places, to allow the code to run with modern default installations of mysql that disallow a default of zero on timestamps.